### PR TITLE
Enable download button on front page of website

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "geist": "^1.3.0",
-        "lucide-react": "^0.371.0",
+        "lucide-react": "^0.441.0",
         "next": "14.1.1",
         "react": "^18",
         "react-dom": "^18",
@@ -3581,11 +3581,11 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
     "node_modules/lucide-react": {
-      "version": "0.371.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.371.0.tgz",
-      "integrity": "sha512-FpUup3kaya7JpGHaoNYn1o0Z8IFvR9w4LeXr2ad20DTr3RFLBXD69bVXagV/I8yWyCJu3it1d1B3bNSa5ui4AA==",
+      "version": "0.441.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.441.0.tgz",
+      "integrity": "sha512-0vfExYtvSDhkC2lqg0zYVW1Uu9GsI4knuV9GP9by5z0Xhc4Zi5RejTxfz9LsjRmCyWVzHCJvxGKZWcRyvQCWVg==",
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/merge2": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "geist": "^1.3.0",
-    "lucide-react": "^0.371.0",
+    "lucide-react": "^0.441.0",
     "next": "14.1.1",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,12 @@
 'use client'
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect } from 'react';
 import { DownloadIcon, GitHubLogoIcon } from "@radix-ui/react-icons"
 import Branding from "@/components/ui/branding";
 import { Button } from '@/components/ui/button';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 const GitHubLink = "https://github.com/spotlightify/spotlightify/";
-const DownloadLink = GitHubLink + "releases";
+const DownloadLink = GitHubLink + "releases/latest";
 
 export default function Home() {
   useEffect(() => {
@@ -19,18 +18,13 @@ export default function Home() {
     <div className='flex gap-10 flex-col mt-14'>
       <Branding className='fade-up-1' />
       <div className='flex gap-5 justify-center fade-up-2'>
-        <TooltipProvider>
-          <Tooltip delayDuration={0}>
-            <TooltipTrigger asChild>
-              <div>
-                <Button disabled className='bg-green-500'><DownloadIcon className="mr-2 h-4 w-4" />Download</Button>
-              </div>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>Coming soon</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <div>
+          <Button className='bg-green-500' asChild>
+            <a href={DownloadLink}>
+              <DownloadIcon className="mr-2 h-4 w-4" />Download Beta
+            </a>
+          </Button>
+        </div>
         <Button asChild>
           <a href={GitHubLink}>
             <GitHubLogoIcon className="mr-2 h-4 w-4" />Github


### PR DESCRIPTION
This PR enables the download button on the front page of the website
and, when clicked, will redirect users to the latest release on GitHub.
